### PR TITLE
Adds `zebrad` as a bundled external binary

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,11 +10,9 @@ use std::{
 
 use tauri::{AppHandle, Manager, RunEvent};
 
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
+// TODO: Add a command for updating the config and restarting `zebrad` child process
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
+fn save_config() {}
 
 fn main() {
     // Spawn initial zebrad process
@@ -27,6 +25,9 @@ fn main() {
     // Spawn a task for reading output and sending it to a channel
     let (zebrad_log_sender, mut zebrad_log_receiver) = tokio::sync::mpsc::channel(100);
     let zebrad_stdout = zebrad.stdout.take().expect("should have anonymous pipe");
+
+    // TODO: Use a blocking tokio/async_runtime thread? The io is blocking (reading the child process output from stdio), so
+    //       it shouldn't use a green thread
     let _log_emitter_handle = std::thread::spawn(move || {
         for line in BufReader::new(zebrad_stdout).lines() {
             // Ignore send errors for now
@@ -48,7 +49,7 @@ fn main() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![save_config])
         .build(tauri::generate_context!())
         .unwrap()
         .run(move |app_handle: &AppHandle, _event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,14 +1,15 @@
 {
   "productName": "zebra-app",
   "version": "0.0.0",
-  "identifier": "com.tauri.dev",
+  "identifier": "zebra.app",
   "build": {
     "beforeDevCommand": "yarn dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "yarn build",
     "frontendDist": "../dist"
   },
-  "app": {"windows": [
+  "app": {
+    "windows": [
       {
         "title": "zebra-app",
         "width": 800,
@@ -28,6 +29,7 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "externalBin": ["binaries/zebrad"]
   }
 }


### PR DESCRIPTION
## Motivation

We want to run zebrad as a child process so that it can be restarted without restarting zebra-app (to apply updated configurations) and to read Zebra's logs from a system pipe.

We want to bundle the zebrad binary so that it won't need to be installed separately for zebra-app to work.

Manual test with `.deb` installer:

![image](https://github.com/ZcashFoundation/zebra-app/assets/5491350/44aafc40-a756-49df-93f9-70a1bbcb76a2)


<details>
Tauri v1.6.0 (latest stable version) has a `Command::new_sidecar()` method for running bundled binaries, but it's not clear if it's included in v2.0.0-beta, and in v1.6.0, it only returns the output after the process has exited, so we want to use a `std::process::Command` so it's possible to read the output while `zebrad` is running.

It may be necessary to use a relative path to the bundled external binaries for this to work with other installers or for Windows.
</details>